### PR TITLE
feat(issue5): Complete Phase 3 Strategy System Refactoring

### DIFF
--- a/crates/arbitrage-core/src/lib.rs
+++ b/crates/arbitrage-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod confidence_scorer;
 pub mod config;
 pub mod error;
 pub mod execution_preparer;
+pub mod market_utils;
 pub mod normalizer;
 pub mod simulation;
 pub mod size_calculator;

--- a/crates/arbitrage-core/src/market_utils.rs
+++ b/crates/arbitrage-core/src/market_utils.rs
@@ -1,0 +1,61 @@
+//! Market utility functions for arbitrage strategies
+
+use crate::strategies::MarketBundle;
+use crate::types::{exchange_constants, ExchangeId, Symbol};
+use rust_decimal::Decimal;
+
+/// Find the best bid (highest price) across multiple exchanges
+pub fn find_best_bid(
+    market_data: &MarketBundle,
+    symbol: &Symbol,
+    exchanges: &[ExchangeId],
+) -> Option<(ExchangeId, Decimal)> {
+    let mut best: Option<(ExchangeId, Decimal)> = None;
+    for &exchange in exchanges {
+        if let Some(ticker) = market_data.get_ticker(exchange, symbol) {
+            if ticker.bid > Decimal::ZERO {
+                if let Some((_, current)) = best {
+                    if ticker.bid > current {
+                        best = Some((exchange, ticker.bid));
+                    }
+                } else {
+                    best = Some((exchange, ticker.bid));
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Find the best ask (lowest price) across multiple exchanges
+pub fn find_best_ask(
+    market_data: &MarketBundle,
+    symbol: &Symbol,
+    exchanges: &[ExchangeId],
+) -> Option<(ExchangeId, Decimal)> {
+    let mut best: Option<(ExchangeId, Decimal)> = None;
+    for &exchange in exchanges {
+        if let Some(ticker) = market_data.get_ticker(exchange, symbol) {
+            if ticker.ask > Decimal::ZERO {
+                if let Some((_, current)) = best {
+                    if ticker.ask < current {
+                        best = Some((exchange, ticker.ask));
+                    }
+                } else {
+                    best = Some((exchange, ticker.ask));
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Get supported spot exchanges for CEX arbitrage
+pub fn get_spot_exchanges() -> Vec<ExchangeId> {
+    exchange_constants::SPOT_EXCHANGES.to_vec()
+}
+
+/// Get supported perpetual exchanges
+pub fn get_perpetual_exchanges() -> Vec<ExchangeId> {
+    exchange_constants::PERPETUAL_EXCHANGES.to_vec()
+}

--- a/crates/arbitrage-core/src/strategies/base.rs
+++ b/crates/arbitrage-core/src/strategies/base.rs
@@ -40,6 +40,77 @@ pub trait Strategy: Send + Sync {
     fn update_config(&mut self, config: StrategyConfig) -> Result<()>;
 }
 
+/// Extended strategy trait with default filter implementation
+/// Eliminates boilerplate by providing common filter logic
+pub trait ArbitrageStrategy: Strategy {
+    /// Expected number of legs for this strategy (default: 2)
+    fn expected_leg_count(&self) -> usize {
+        2
+    }
+
+    /// Validate signal with default criteria
+    fn validate_signal(&self, signal: &RawSignal, context: &FilterContext) -> Result<bool> {
+        if !signal.is_valid() {
+            return Ok(false);
+        }
+
+        if signal.legs.len() != self.expected_leg_count() {
+            return Ok(false);
+        }
+
+        let exchanges = signal.get_exchanges();
+        if !exchanges.iter().all(|ex| context.is_exchange_allowed(*ex)) {
+            return Ok(false);
+        }
+
+        if signal.expected_profit_bps < context.min_profit_bps {
+            return Ok(false);
+        }
+
+        let total = signal.total_notional();
+        if total > context.max_exposure {
+            return Ok(false);
+        }
+
+        self.validate_inventory(signal, context)
+    }
+
+    /// Inventory validation hook (default: skip)
+    fn validate_inventory(&self, _signal: &RawSignal, _context: &FilterContext) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+/// Macro to create strategy new() function with default config
+#[macro_export]
+macro_rules! strategy_new {
+    ($type:ident, $strategy_id:expr) => {
+        impl $type {
+            pub fn new() -> Self {
+                let config = StrategyConfig {
+                    min_profit_bps: StrategyLimits::get_min_profit_bps($strategy_id),
+                    max_exposure: StrategyLimits::get_max_exposure($strategy_id),
+                    custom_params: StrategyUtils::create_base_custom_params(),
+                    ..Default::default()
+                };
+                Self { config }
+            }
+        }
+    };
+}
+
+/// Macro to implement Default for strategy using strategy_new!
+#[macro_export]
+macro_rules! strategy_default {
+    ($type:ident) => {
+        impl Default for $type {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
 /// Bundle of market data for strategy analysis
 #[derive(Debug, Clone)]
 pub struct MarketBundle {
@@ -193,12 +264,38 @@ impl RawSignal {
         self.legs.push(leg);
     }
 
+    /// Add a buy leg with fluent builder pattern
+    pub fn add_buy_leg(mut self, exchange: ExchangeId, price: Decimal, quantity: Decimal) -> Self {
+        let leg = TradeLeg::new(exchange, self.symbol.clone(), Side::Buy, price, quantity);
+        self.legs.push(leg);
+        self
+    }
+
+    /// Add a sell leg with fluent builder pattern
+    pub fn add_sell_leg(mut self, exchange: ExchangeId, price: Decimal, quantity: Decimal) -> Self {
+        let leg = TradeLeg::new(exchange, self.symbol.clone(), Side::Sell, price, quantity);
+        self.legs.push(leg);
+        self
+    }
+
     pub fn set_profit_bps(&mut self, profit_bps: i32) {
         self.expected_profit_bps = profit_bps;
     }
 
+    /// Set profit in basis points with fluent builder pattern
+    pub fn with_profit_bps(mut self, bps: i32) -> Self {
+        self.expected_profit_bps = bps;
+        self
+    }
+
     pub fn add_metadata(&mut self, key: impl Into<String>, value: serde_json::Value) {
         self.metadata.insert(key.into(), value);
+    }
+
+    /// Add metadata with fluent builder pattern
+    pub fn with_metadata(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.metadata.insert(key.into(), value);
+        self
     }
 
     /// Validate that the signal has valid legs and profit

--- a/crates/arbitrage-core/src/strategies/strategies_specifics.rs
+++ b/crates/arbitrage-core/src/strategies/strategies_specifics.rs
@@ -1,3 +1,4 @@
+use crate::types::ToBps;
 /// Strategy-specific configurations, constants, and utilities
 ///
 /// This module contains strategy-specific parameters, default configurations,
@@ -6,6 +7,71 @@ use crate::ExchangeId;
 use rust_decimal::Decimal;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+
+/// Trait for calculating fees and net profit
+pub trait FeeCalculator {
+    fn total_fee_bps(&self, buy_fee: Decimal, sell_fee: Decimal) -> i32;
+    fn net_profit_after_fees(&self, gross_profit_bps: i32, total_fee_bps: i32) -> i32;
+}
+
+impl FeeCalculator for () {
+    fn total_fee_bps(&self, buy_fee: Decimal, sell_fee: Decimal) -> i32 {
+        ((buy_fee + sell_fee) * Decimal::from(100)).to_bps_or_zero()
+    }
+
+    fn net_profit_after_fees(&self, gross_profit_bps: i32, total_fee_bps: i32) -> i32 {
+        gross_profit_bps - total_fee_bps
+    }
+}
+
+/// Trait for convenient access to typed values from HashMap<String, Value>
+pub trait ConfigExtensions {
+    fn get_f64(&self, key: &str) -> Option<f64>;
+    fn get_i64(&self, key: &str) -> Option<i64>;
+    fn get_bool(&self, key: &str) -> Option<bool>;
+    fn get_decimal(&self, key: &str) -> Option<Decimal>;
+    fn get_f64_or(&self, key: &str, default: f64) -> f64;
+    fn get_i64_or(&self, key: &str, default: i64) -> i64;
+    fn get_bool_or(&self, key: &str, default: bool) -> bool;
+    fn get_decimal_or(&self, key: &str, default: Decimal) -> Decimal;
+}
+
+impl ConfigExtensions for HashMap<String, Value> {
+    fn get_f64(&self, key: &str) -> Option<f64> {
+        self.get(key).and_then(|v| v.as_f64())
+    }
+
+    fn get_i64(&self, key: &str) -> Option<i64> {
+        self.get(key).and_then(|v| v.as_i64())
+    }
+
+    fn get_bool(&self, key: &str) -> Option<bool> {
+        self.get(key).and_then(|v| v.as_bool())
+    }
+
+    fn get_decimal(&self, key: &str) -> Option<Decimal> {
+        self.get(key)
+            .and_then(|v| v.as_f64())
+            .map(|f| Decimal::try_from(f).ok())
+            .flatten()
+    }
+
+    fn get_f64_or(&self, key: &str, default: f64) -> f64 {
+        self.get_f64(key).unwrap_or(default)
+    }
+
+    fn get_i64_or(&self, key: &str, default: i64) -> i64 {
+        self.get_i64(key).unwrap_or(default)
+    }
+
+    fn get_bool_or(&self, key: &str, default: bool) -> bool {
+        self.get_bool(key).unwrap_or(default)
+    }
+
+    fn get_decimal_or(&self, key: &str, default: Decimal) -> Decimal {
+        self.get_decimal(key).unwrap_or(default)
+    }
+}
 
 /// Default configuration parameters for CEX arbitrage strategy
 pub struct CexArbitrageDefaults;

--- a/crates/arbitrage-core/src/types.rs
+++ b/crates/arbitrage-core/src/types.rs
@@ -525,3 +525,84 @@ impl ExchangeStatus {
         }
     }
 }
+
+/// Trait for converting Decimal values to basis points (bps)
+pub trait ToBps {
+    fn to_bps(&self) -> Option<i32>;
+    fn to_bps_or_zero(&self) -> i32;
+}
+
+impl ToBps for Decimal {
+    fn to_bps(&self) -> Option<i32> {
+        (self * Decimal::from(10000)).to_i32()
+    }
+
+    fn to_bps_or_zero(&self) -> i32 {
+        self.to_bps().unwrap_or(0)
+    }
+}
+
+/// Trait for calculating mid price from market data
+pub trait MidPrice {
+    fn mid_price(&self) -> Option<Decimal>;
+}
+
+impl MidPrice for crate::strategies::Ticker {
+    fn mid_price(&self) -> Option<Decimal> {
+        if self.bid.is_zero() && self.ask.is_zero() {
+            None
+        } else {
+            Some((self.bid + self.ask) / Decimal::from(2))
+        }
+    }
+}
+
+impl MidPrice for OrderBook {
+    fn mid_price(&self) -> Option<Decimal> {
+        match (self.best_ask(), self.best_bid()) {
+            (Some(ask), Some(bid)) => Some((ask.price + bid.price) / Decimal::from(2)),
+            _ => None,
+        }
+    }
+}
+
+/// Exchange constants for convenience
+pub mod exchange_constants {
+    use super::ExchangeId;
+
+    pub const ALL_EXCHANGES: [ExchangeId; 12] = [
+        ExchangeId::OKX,
+        ExchangeId::ByBit,
+        ExchangeId::MEXC,
+        ExchangeId::GateIo,
+        ExchangeId::Bitstamp,
+        ExchangeId::Kraken,
+        ExchangeId::HTX,
+        ExchangeId::BingX,
+        ExchangeId::Hyperliquid,
+        ExchangeId::KuCoin,
+        ExchangeId::Bitget,
+        ExchangeId::Binance,
+    ];
+
+    pub const PERPETUAL_EXCHANGES: [ExchangeId; 3] =
+        [ExchangeId::OKX, ExchangeId::ByBit, ExchangeId::MEXC];
+
+    pub const SPOT_EXCHANGES: [ExchangeId; 6] = [
+        ExchangeId::OKX,
+        ExchangeId::ByBit,
+        ExchangeId::MEXC,
+        ExchangeId::GateIo,
+        ExchangeId::Bitstamp,
+        ExchangeId::Kraken,
+    ];
+}
+
+/// Calculate profit in basis points from buy and sell prices
+pub fn calculate_profit_bps(buy_price: Decimal, sell_price: Decimal) -> Option<i32> {
+    if buy_price.is_zero() {
+        return None;
+    }
+    let profit_ratio = (sell_price - buy_price) / buy_price;
+    (profit_ratio * Decimal::from(10000)).to_i32()
+}


### PR DESCRIPTION
Complete implementation of all Issue #5 tasks.

## Changes

### Helper Traits (types.rs, strategies_specifics.rs)
-  trait for Decimal to basis point conversion
-  trait for Ticker and OrderBook
-  trait for fee calculations
-  trait for typed HashMap access

### Exchange Constants (types.rs)
- : All 12 exchanges
- : 3 perpetual-capable exchanges  
- : 6 spot exchanges

### Helper Functions (types.rs)
-  for profit calculation

### Market Utilities (market_utils.rs - NEW)
-  - Find highest bid across exchanges
-  - Find lowest ask across exchanges
-  - Get spot exchange list
-  - Get perpetual exchange list

### RawSignal Builder Extensions (base.rs)
-  - Add buy leg with fluent builder
-  - Add sell leg with fluent builder
-  - Set profit in bps with fluent builder
-  - Add metadata with fluent builder

### ArbitrageStrategy Trait (base.rs)
- Extended strategy trait with  default implementation
- Consolidates common filter logic
-  hook for inventory checks

### Strategy Macros (base.rs)
-  - Creates new() with default config
-  - Implements Default using strategy_new!

## Validation (worktree: /root/zanto/issue5-worktree)
- cargo check --package arbitrage-core: PASS
- cargo test --package arbitrage-core --lib: PASS
- cargo test --package arbitrage-core --test config_test: PASS (11 tests)